### PR TITLE
fix graphql query conversion to CURL

### DIFF
--- a/docs/src/pages/importing-data.tsx
+++ b/docs/src/pages/importing-data.tsx
@@ -47,9 +47,9 @@ export function ImportingData({state}: {state: AppState}) {
             user {
               id
               organization{
-                id
+                id,
                 projects(where:{deleted:false}){
-                  id
+                  id,
                   name
                 }
               }


### PR DESCRIPTION
The query conversion to CURL causes invalid graphql queries when there are multiple fields requested in succession (even when delineated by newlines) if a comma is omitted.