### PR TITLE
Fix annotations_output_dir typo in README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,9 +39,9 @@ import labelbox2pascal as lb2pa
 # set labeled_data to the file path of the Labelbox JSON export
 labeled_data = 'test-fixtures/labelbox_1.json'
 
-# set ann_output_dir to the file path of the directory to write Pascal VOC
+# set annotations_output_dir to the file path of the directory to write Pascal VOC
 # annotation files. The directory must exist.
-ann_output_dir = './Annotations'
+annotations_output_dir = './Annotations'
 
 # set images_output_dir to the file path of the directory to write images.
 # The directory must exist.
@@ -50,7 +50,7 @@ images_output_dir = './Images'
 # call the Labelbox to Pascal conversion
 # NOTE: make sure to specify the correct label_format based on the export
 #  format chosen on Labelbox; 'WKT' or 'XY'.
-lb2pa.from_json(labeled_data=labeled_data, ann_output_dir=ann_output_dir,
+lb2pa.from_json(labeled_data=labeled_data, annotations_output_dir=annotations_output_dir,
                 images_output_dir=images_output_dir, label_format='WKT')
 ```
 


### PR DESCRIPTION
Closes #122 