### PR TITLE
fix ontology indexing when exporting to COCO

### DIFF
--- a/Guide/converters/export_to_coco/export_to_coco.py
+++ b/Guide/converters/export_to_coco/export_to_coco.py
@@ -82,15 +82,15 @@ def layer_iterator(feature_map, node_layer, encoded_value=0, parent_featureSchem
                 node_type = "leaf_option"
         node_dict = { node['featureSchemaId'] : {"name" : node_name, "color" : color, "type" : node_type, "kind" : node_kind, "parent_featureSchemaIds" : parent_featureSchemaIds, "encoded_value" : encoded_value}}
         feature_map.update(node_dict)
-    if next_layer:
-        feature_map, next_layer, encoded_value, parent_featureSchemaIds, parent_featureSchemaId = layer_iterator(
-            feature_map=feature_map, 
-            node_layer=next_layer, 
-            encoded_value=encoded_value, 
-            parent_featureSchemaIds=parent_featureSchemaIds, 
-            parent_featureSchemaId=node['featureSchemaId']
-            )
-        parent_featureSchemaIds = parent_featureSchemaIds[:-1]
+        if next_layer:
+            feature_map, next_layer, encoded_value, parent_featureSchemaIds, parent_featureSchemaId = layer_iterator(
+                feature_map=feature_map, 
+                node_layer=next_layer, 
+                encoded_value=encoded_value, 
+                parent_featureSchemaIds=parent_featureSchemaIds, 
+                parent_featureSchemaId=node['featureSchemaId']
+                )
+            parent_featureSchemaIds = parent_featureSchemaIds[:-1]
     return feature_map, next_layer, encoded_value, parent_featureSchemaIds, parent_featureSchemaId
 
 def coco_bbox_converter(data_row_id, annotation, category_id):


### PR DESCRIPTION
Ontology indexing does not occur correctly for subclasses of tools.

The fix was getting the recursive call to run on each `node` in the `node_layer` to index correctly.